### PR TITLE
Update Symfony deps to follow semantic versioning

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,9 +12,9 @@
     ],
     "require": {
         "php": ">=5.3.2",
-        "symfony/http-foundation": ">=2.0.4, <=2.4.x-dev",
-        "symfony/http-kernel": ">=2.0.4, <=2.4.x-dev",
-        "symfony/event-dispatcher": ">=2.0.4, <=2.4.x-dev"
+        "symfony/http-foundation": "~2.0",
+        "symfony/http-kernel": "~2.0",
+        "symfony/event-dispatcher": "~2.0"
     },
     "require-dev": {
         "phpunit/phpunit": "3.7"


### PR DESCRIPTION
The bundle is currently not compatible with Symfony 2.5.

Symfony follows semantic versioning, so you should be save to use `~2.0` which means every version without backwards compatibility issues.
