### PR TITLE
Fixed problem with post parameters passed as 3rd argument to Request::create()

### DIFF
--- a/HttpKernel/RemoteHttpKernel.php
+++ b/HttpKernel/RemoteHttpKernel.php
@@ -163,7 +163,7 @@ class RemoteHttpKernel implements HttpKernelInterface
         if (!empty($content)) {
             $postfields = $content;
         } else if (count($request->request->all()) > 0) {
-            $postfields = $request->request->all();
+            $postfields = http_build_query($request->request->all());
         }
 
         $curl->setOption(CURLOPT_POSTFIELDS, $postfields);


### PR DESCRIPTION
When doing:

```
$request = Symfony\Component\HttpFoundation\Request::create(
    'example.com',
    'POST',
    [
        'some_key'       => 'some_val',
        'some_other_key' => 'some_other_val',
    ]
);
```

those parameters needs to be converted into http query string inside RemoteHttpKernel::setPostFields() to be properly send.
